### PR TITLE
avoid exception when the current value is None

### DIFF
--- a/otestpoint/labtools/delta.py
+++ b/otestpoint/labtools/delta.py
@@ -205,6 +205,7 @@ class Delta(Subject,Observer):
                     # it match the current value structure
                     # (i.e. single value or list if values)
                     if previous != None and \
+                       data[timestamp][tag] != None and \
                        hasattr(previous, '__iter__') == hasattr(data[timestamp][tag], '__iter__') and \
                        pd.notnull(previous):
                         if data[timestamp][tag] >= previous:


### PR DESCRIPTION
I got an exception when running because the new value for an element was None, whilst the old value was happy, this seemed to be the easiest way to get past it...